### PR TITLE
Fix rounding float to integer

### DIFF
--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -76,7 +76,7 @@ export function saveTypos(outDir: string, typos: string[], type: string) {
 
 // covert float number to integer
 export function floatToInt(float: number): number {
-  return Math.ceil(float * 255);
+  return Math.round(float * 255);
 }
 
 // convert interger to hex


### PR DESCRIPTION
Fix rounding float to integer.

When the RGB values are pulled from figma to figgo they are transformed to HEX incorrectly by a small difference, for example in Figma a HEX colour can be `#ffb600` then processed in figgo it will be `#ffb800`.

This PR fixes issue #7 